### PR TITLE
Fix linker matches in the case that they span multiple rgroups

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupMatch.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupMatch.h
@@ -33,8 +33,8 @@ struct RGroupMatch {
     auto rGroupsString = std::accumulate(
         rgroups.cbegin(), rgroups.cend(), std::string(),
         [](std::string s, const std::pair<int, RData>& rgroup) {
-          return std::move(s) + '|' + std::to_string(rgroup.first) + ':' +
-                 rgroup.second->toString();
+          return std::move(s) + "\n\t(" + std::to_string(rgroup.first) + ':' +
+                 rgroup.second->toString() + ')';
         });
     std::stringstream ss;
     ss << "Match coreIdx " << core_idx << " missing count "

--- a/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupScore.cpp
@@ -13,7 +13,7 @@
 #include "RGroupScore.h"
 #include <vector>
 #include <map>
-
+#include <algorithm>
 namespace RDKit {
 
 // stupid total score
@@ -29,7 +29,7 @@ double matchScore(const std::vector<size_t> &permutation,
             << std::endl;
   std::cerr << "Scoring permutation "
             << " num matches: " << matches.size() << std::endl;
-#endif
+
 
   BOOST_LOG(rdDebugLog) << "Scoring" << std::endl;
   for (size_t m = 0; m < permutation.size(); ++m) {  // for each molecule
@@ -37,14 +37,14 @@ double matchScore(const std::vector<size_t> &permutation,
       << "Molecule " << m << " " << matches[m][permutation[m]].toString()
       << std::endl;
   }
-
-    // For each label (group)
-  for (int l : labels) {
+#endif
+  // For each label (group)
+  for(auto l : labels ) {
 #ifdef DEBUG
     std::cerr << "Label: " << l << std::endl;
 #endif
     std::vector<std::map<std::string, unsigned int>> matchSetVect;
-    std::map<std::set<int>, int> linkerMatchSet;
+    std::map<std::set<int>, size_t> linkerMatchSet;
 
     for (size_t m = 0; m < permutation.size(); ++m) {  // for each molecule
 
@@ -110,13 +110,14 @@ double matchScore(const std::vector<size_t> &permutation,
     }
 
     // overweight linkers with the same attachments points....
-    //  because these belong to 2 rgroups we really want these to stay
+    //  because these belong to 2 (or more) rgroups we really want these to stay
+    //  the size of the set is the number of labels that are being used
     //  ** this heuristic really should be taken care of above **
     int maxLinkerMatches = 0;
     for (const auto &it : linkerMatchSet) {
-      if (it.second > 1) {
-        if (it.second > maxLinkerMatches) {
-          maxLinkerMatches = it.second;
+      if (it.first.size() > 1 || it.second > 1) {
+        if (it.first.size() > maxLinkerMatches) {
+          maxLinkerMatches = std::max(it.first.size(), it.second);
         }
       }
     }

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -1484,39 +1484,38 @@ N[*:1]
 O[*:1]
 S[*:1]
 C(N[*:1])[*:2]
+P[*:1]
 O[*:1]
-O[*:1]
-C[*:1]
+N[*:1]
 C[*:1]
 CC(C)[*:1]
 c1ccc(C[*:1])cc1
 c1ccc(C[*:1])cc1
-CCC[*:1]
+OC[*:1]
 CC(C)C[*:1]
 Rgroup===R2
 [H][*:2]
 [H][*:2]
 [H][*:2]
 C(N[*:1])[*:2]
-P[*:2]
+O[*:2]
 N[*:2]
-N[*:2]
+C[*:2]
 CC[*:2]
 CC[*:2]
 CC[*:2]
 OC[*:2]
-OC[*:2]
+CCC[*:2]
 CCCC[*:2]
 )RES";
-#ifdef DEBUG
+
     if (ss.str() != expected) {
       std::cerr << __LINE__ << " ERROR got\n"
                 << ss.str() << "\nexpected\n"
                 << expected << std::endl;
     }
-#else
+
     TEST_ASSERT(ss.str() == expected);
-#endif
   }
 }
 
@@ -1960,7 +1959,7 @@ M  END
       // on any atom is returning "Core:C1CCC([*:5])([*:6])C([*:1])C1
       // R1:C(C[*:1])[*:1]"- I've seen this before and I think it is an error
       // with the ranking function. params.onlyMatchAtRGroups = true;
-      params.scoreMethod = FingerprintVariance;
+      //params.scoreMethod = FingerprintVariance;
       if (matchAtRGroup) {
         params.labels = MDLRGroupLabels;
       }
@@ -2165,7 +2164,6 @@ void testUserMatchTypes() {
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
-
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";


### PR DESCRIPTION
The issue was that when an r-group spanned multiple r-labels, it wasn't being considered as filling in two or more r-groups, only one.

this does change the ordering of the permutation tests,  I *think* this is ok, but II would like a second sanity check.